### PR TITLE
Disable ter-indent rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - `no-console` rule
+- `indent` rule instead of `ter-indent`
 
 ### Removed
 - `ter-indent` rule due to strange behaviour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - `no-console` rule
 
+### Removed
+- `ter-indent` rule due to strange behaviour
+
 ## [0.3.0] - 2019-02-21
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -55,11 +55,7 @@ module.exports = {
             'constructor': 'never'
         }],
         'ter-arrow-parens': false,
-        'ter-indent': [
-            true,
-            4,
-            { 'SwitchCase': 1 },
-        ],
+        'ter-indent': false,
         'ter-max-len': [true, 160, 4, {
             'ignoreComments': true,
             'ignoreUrls': true,

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
             'severity': 'warning'
         },
         'import-name': false,
+        'indent': [true, 'spaces', 4],
         'max-line-length': false,
         'member-ordering': {
             'severity': 'warning',


### PR DESCRIPTION
#5 cannot be solved with `ter-indent` rule enabled. The rule contradicts itself sometimes.

Resolves #5 